### PR TITLE
Fixed check if share works to `get` method instead of checking that r…

### DIFF
--- a/posh/product.py
+++ b/posh/product.py
@@ -219,5 +219,5 @@ class Product:
         account.login()
         r = account.session.put(f"https://poshmark.com/vm-rest/users/self/shared_posts/{listing_id}",
                             {})
-        if r.content.keys() == 'req_id':
-            return True  # Successfully shared.
+        if r.json().get('req_id'):
+            return True


### PR DESCRIPTION
…eq_id was only list member.